### PR TITLE
Fuseki 4.10.0 update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,14 @@
-FROM openjdk:17-alpine@sha256:a996cdcc040704ec6badaf5fecf1e144c096e00231a29188596c784bcf858d05
+FROM yti-docker-java-base:corretto-17.0.10
 RUN apk add --update pwgen bash wget ca-certificates && rm -rf /var/cache/apk/*
 
+# Fuseki 4.10.0
+ENV FUSEKI_SHA512 a4be52cc5f7f8767e362f893f28721f2887a3544ed779cd58fe0b32733575d97411b5a3bc2243995d6408e545bdefc5ab41c00b2c5d074df1dc0ca5063db5f83
+ENV FUSEKI_VERSION 4.10.0
+
 # Fuseki 4.6.1
-ENV FUSEKI_SHA512 12a7c242584fa739d0d1d2a4025267552069d8bf7b411545d0328e3cacc3bceddaac0584b405772b51464c33f695da86182a60480c72a661264677281771e700
-ENV FUSEKI_VERSION 4.6.1
+# ENV FUSEKI_SHA512 12a7c242584fa739d0d1d2a4025267552069d8bf7b411545d0328e3cacc3bceddaac0584b405772b51464c33f695da86182a60480c72a661264677281771e700
+# ENV FUSEKI_VERSION 4.6.1
 
-# Fuseki 3.13.1
-# ENV FUSEKI_SHA512 1960d3e057cdcaaa0811b33b57b86145fb0fb675eee1a6dd2d27a111313689e70ba8fa36b9ca66784cf9130ae5753bf50e32e82d9e3a7bba2786a0fc4ae7f056
-# ENV FUSEKI_VERSION 3.13.1
-
-# Fuseki 2.3.0
-#ENV FUSEKI_SHA1 c2513b30a08ba284a4d71c587b9fc51e10f632ac
-#ENV FUSEKI_VERSION 2.3.0
-
-ENV FUSEKI_MIRROR http://www.eu.apache.org/dist/
 ENV FUSEKI_ARCHIVE http://archive.apache.org/dist/
 
 VOLUME /fuseki
@@ -22,8 +17,7 @@ ENV FUSEKI_HOME /jena-fuseki
 
 WORKDIR /tmp
 RUN echo "$FUSEKI_SHA512  fuseki.tar.gz" > fuseki.tar.gz.sha512
-RUN     wget -O fuseki.tar.gz $FUSEKI_MIRROR/jena/binaries/apache-jena-fuseki-$FUSEKI_VERSION.tar.gz || \
-        wget -O fuseki.tar.gz $FUSEKI_ARCHIVE/jena/binaries/apache-jena-fuseki-$FUSEKI_VERSION.tar.gz && sha512sum -c fuseki.tar.gz.sha512 && \
+RUN wget -O fuseki.tar.gz $FUSEKI_ARCHIVE/jena/binaries/apache-jena-fuseki-$FUSEKI_VERSION.tar.gz && sha512sum -c fuseki.tar.gz.sha512 && \
         tar zxf fuseki.tar.gz && \
         mv apache-jena-fuseki* $FUSEKI_HOME && \
         rm fuseki.tar.gz* && \

--- a/config.ttl
+++ b/config.ttl
@@ -20,6 +20,7 @@
      <#imports>
      <#prov>
      <#scheme>
+     <#terminology>
    ) .
 
 # TDB
@@ -138,6 +139,25 @@ tdb:GraphTDB    rdfs:subClassOf  ja:Model .
 	
 <#scheme_dataset> rdf:type tdb:DatasetTDB ;
     tdb:location "/fuseki/databases/SCHEME_TDB" ;
+    tdb:unionDefaultGraph   true ;
+    # Query timeout on this dataset (1s, 1000 milliseconds)
+    # ja:context [ ja:cxtName "arq:queryTimeout" ;  ja:cxtValue "1000" ] ;
+    .
+
+# terminology service configuration
+
+<#terminology>  rdf:type fuseki:Service ;
+    fuseki:name                   "terminology" ;       # http://host:port/search
+    fuseki:dataset           <#terminology_dataset> ; 
+    fuseki:serviceQuery           "sparql" ;     # http://host:port/prov/sparql?query=...
+    fuseki:serviceUpdate          "update" ;     # http://host:port/prov/update?query=...
+	fuseki:serviceReadWriteGraphStore    "data" ; # http://host:port/prov/data?query=...
+    fuseki:serviceUpload          "upload" ;     # http://host:post/prov/upload?graph="any"
+	fuseki:serviceReadGraphStore  "get" ;        # http://host:post/prov/get?graph=default
+	.
+	
+<#terminology_dataset> rdf:type tdb:DatasetTDB ;
+    tdb:location "/fuseki/databases/TERMINOLOGY_TDB" ;
     tdb:unionDefaultGraph   true ;
     # Query timeout on this dataset (1s, 1000 milliseconds)
     # ja:context [ ja:cxtName "arq:queryTimeout" ;  ja:cxtValue "1000" ] ;


### PR DESCRIPTION
- Add new data se for terminology (YTI-3886)
- Use yti java base image
- Update Fuseki to version 4.10.0
- Clean up Dockerfile: remove old versions and www.eu.apache.org mirror (does not exist any more)