### PR TITLE
Create TDB2 dataset for terminology

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,7 @@ RUN wget -O fuseki.tar.gz $FUSEKI_ARCHIVE/jena/binaries/apache-jena-fuseki-$FUSE
 COPY log4j2.properties /jena-fuseki/log4j2.properties
 COPY shiro.ini /jena-fuseki/shiro.ini
 COPY config.ttl /jena-fuseki/config.ttl
+COPY configuration /jena-fuseki/configuration
 COPY docker-entrypoint.sh /
 RUN chmod 755 /docker-entrypoint.sh
 

--- a/config.ttl
+++ b/config.ttl
@@ -20,7 +20,6 @@
      <#imports>
      <#prov>
      <#scheme>
-     <#terminology>
    ) .
 
 # TDB
@@ -139,25 +138,6 @@ tdb:GraphTDB    rdfs:subClassOf  ja:Model .
 	
 <#scheme_dataset> rdf:type tdb:DatasetTDB ;
     tdb:location "/fuseki/databases/SCHEME_TDB" ;
-    tdb:unionDefaultGraph   true ;
-    # Query timeout on this dataset (1s, 1000 milliseconds)
-    # ja:context [ ja:cxtName "arq:queryTimeout" ;  ja:cxtValue "1000" ] ;
-    .
-
-# terminology service configuration
-
-<#terminology>  rdf:type fuseki:Service ;
-    fuseki:name                   "terminology" ;       # http://host:port/search
-    fuseki:dataset           <#terminology_dataset> ; 
-    fuseki:serviceQuery           "sparql" ;     # http://host:port/prov/sparql?query=...
-    fuseki:serviceUpdate          "update" ;     # http://host:port/prov/update?query=...
-	fuseki:serviceReadWriteGraphStore    "data" ; # http://host:port/prov/data?query=...
-    fuseki:serviceUpload          "upload" ;     # http://host:post/prov/upload?graph="any"
-	fuseki:serviceReadGraphStore  "get" ;        # http://host:post/prov/get?graph=default
-	.
-	
-<#terminology_dataset> rdf:type tdb:DatasetTDB ;
-    tdb:location "/fuseki/databases/TERMINOLOGY_TDB" ;
     tdb:unionDefaultGraph   true ;
     # Query timeout on this dataset (1s, 1000 milliseconds)
     # ja:context [ ja:cxtName "arq:queryTimeout" ;  ja:cxtValue "1000" ] ;

--- a/configuration/terminology.ttl
+++ b/configuration/terminology.ttl
@@ -1,0 +1,34 @@
+@prefix :       <http://base/#> .
+@prefix fuseki: <http://jena.apache.org/fuseki#> .
+@prefix ja:     <http://jena.hpl.hp.com/2005/11/Assembler#> .
+@prefix rdf:    <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs:   <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix tdb2:   <http://jena.apache.org/2016/tdb#> .
+
+:tdb_dataset_readwrite
+        rdf:type       tdb2:DatasetTDB2;
+        tdb2:location  "/fuseki/databases/terminology_tdb2" .
+
+:service  rdf:type  fuseki:Service;
+        rdfs:label       "TDB2 terminology";
+        fuseki:dataset   :tdb_dataset_readwrite;
+        fuseki:endpoint  [ fuseki:name       "sparql";
+                           fuseki:operation  fuseki:query
+                         ];
+        fuseki:endpoint  [ fuseki:name       "query";
+                           fuseki:operation  fuseki:query
+                         ];
+        fuseki:endpoint  [ fuseki:operation  fuseki:update ];
+        fuseki:endpoint  [ fuseki:operation  fuseki:query ];
+        fuseki:endpoint  [ fuseki:operation  fuseki:gsp-rw ];
+        fuseki:endpoint  [ fuseki:name       "get";
+                           fuseki:operation  fuseki:gsp-r
+                         ];
+        fuseki:endpoint  [ fuseki:name       "data";
+                           fuseki:operation  fuseki:gsp-rw
+                         ];
+        fuseki:endpoint  [ fuseki:name       "update";
+                           fuseki:operation  fuseki:update
+                         ];
+        fuseki:name      "terminology" .
+

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -37,6 +37,7 @@ cp "$FUSEKI_HOME/log4j2.properties" "$FUSEKI_BASE/log4j2.properties"
 
 echo "Copying config.ttl to $FUSEKI_BASE"
 cp "$FUSEKI_HOME/config.ttl" "$FUSEKI_BASE/config.ttl"
+cp -r "$FUSEKI_HOME/configuration" "$FUSEKI_BASE"
 
 # $ADMIN_PASSWORD can always override
 if [ -n "$ADMIN_PASSWORD" ] ; then

--- a/shiro.ini
+++ b/shiro.ini
@@ -21,7 +21,7 @@ plainMatcher=org.apache.shiro.authc.credential.SimpleCredentialsMatcher
 #iniRealm=org.apache.shiro.realm.text.IniRealm
 iniRealm.credentialsMatcher = $plainMatcher
 
-#localhost=org.apache.jena.fuseki.authz.LocalhostFilter
+localhostFilter=org.apache.jena.fuseki.authz.LocalhostFilter
 
 [users]
 # Implicitly adds "iniRealm =  org.apache.shiro.realm.text.IniRealm"
@@ -31,8 +31,10 @@ admin=pw
 
 [urls]
 ## Control functions open to anyone
-/$/status = anon
-/$/ping   = anon
+/$/status  = anon
+/$/ping    = anon
+
+/$/compact/** = localhostFilter
 
 ## and the rest are restricted
 /$/** = authcBasic,user[admin]


### PR DESCRIPTION
- Remove terminology TDB1 dataset and add TDB2 config under configuration directory, see [documentation](https://jena.apache.org/documentation/fuseki2/fuseki-configuration.html)
- Expose compact API endpoint (enable LocalhostFilter in shiro.ini)