### PR TITLE
move "core" dataset to tdb2

### DIFF
--- a/config.ttl
+++ b/config.ttl
@@ -14,7 +14,6 @@
    ja:context [ ja:cxtName "arq:queryTimeout" ;  ja:cxtValue "300000" ] ;
    # ja:loadClass "your.code.Class" ;
    fuseki:services (
-     <#core>
      <#user>
      <#concepts>
      <#imports>
@@ -28,25 +27,7 @@ tdb:DatasetTDB  rdfs:subClassOf  ja:RDFDataset .
 tdb:GraphTDB    rdfs:subClassOf  ja:Model .
 
 
- # Core service configuration
-
-<#core>  rdf:type fuseki:Service ;
-    fuseki:name                   "core" ;       # http://host:port/search
-    fuseki:dataset           <#core_dataset> ; 
-    fuseki:serviceQuery           "sparql" ;     # http://host:port/search/sparql?query=...
-    fuseki:serviceUpdate          "update" ;     # http://host:port/core/update?query=...
-	fuseki:serviceReadWriteGraphStore    "data" ; # http://host:port/core/data?query=...
-    fuseki:serviceUpload          "upload" ;     # http://host:post/core/upload?graph="any"
-	fuseki:serviceReadGraphStore  "get" ;        # http://host:post/core/get?graph=default
-	.
-	
-<#core_dataset> rdf:type tdb:DatasetTDB ;
-    tdb:location "/fuseki/databases/CORE_TDB" ;
-    tdb:unionDefaultGraph   true ;
-    # Query timeout on this dataset (1s, 1000 milliseconds)
-    # ja:context [ ja:cxtName "arq:queryTimeout" ;  ja:cxtValue "1000" ] ;
-    .
-
+ # User service configuration
 
 <#user>  rdf:type fuseki:Service ;
     fuseki:name                   "users" ;    # http://host:port/users
@@ -66,7 +47,7 @@ tdb:GraphTDB    rdfs:subClassOf  ja:Model .
     # ja:context [ ja:cxtName "arq:queryTimeout" ;  ja:cxtValue "1000" ] ;
     . 
 
- # Concept service configuration
+# Concept service configuration
 
 <#concepts>  rdf:type fuseki:Service ;
     fuseki:name                   "concept" ;       # http://host:port/search
@@ -83,10 +64,9 @@ tdb:GraphTDB    rdfs:subClassOf  ja:Model .
     tdb:unionDefaultGraph   true ;
     # Query timeout on this dataset (1s, 1000 milliseconds)
     # ja:context [ ja:cxtName "arq:queryTimeout" ;  ja:cxtValue "1000" ] ;
-    .	
-	
-	
-	 # imports service configuration
+    .
+
+# Imports service configuration
 
 <#imports>  rdf:type fuseki:Service ;
     fuseki:name                   "imports" ;       # http://host:port/search
@@ -104,8 +84,8 @@ tdb:GraphTDB    rdfs:subClassOf  ja:Model .
     # Query timeout on this dataset (1s, 1000 milliseconds)
     # ja:context [ ja:cxtName "arq:queryTimeout" ;  ja:cxtValue "1000" ] ;
     .
-    
-    # prov service configuration
+
+# Prov service configuration
 
 <#prov>  rdf:type fuseki:Service ;
     fuseki:name                   "prov" ;       # http://host:port/search
@@ -124,7 +104,7 @@ tdb:GraphTDB    rdfs:subClassOf  ja:Model .
     # ja:context [ ja:cxtName "arq:queryTimeout" ;  ja:cxtValue "1000" ] ;
     .
 
-# scheme service configuration
+# Scheme service configuration
 
 <#scheme>  rdf:type fuseki:Service ;
     fuseki:name                   "scheme" ;       # http://host:port/search

--- a/configuration/core.ttl
+++ b/configuration/core.ttl
@@ -1,0 +1,35 @@
+@prefix :       <http://base/#> .
+@prefix fuseki: <http://jena.apache.org/fuseki#> .
+@prefix ja:     <http://jena.hpl.hp.com/2005/11/Assembler#> .
+@prefix rdf:    <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs:   <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix tdb2:   <http://jena.apache.org/2016/tdb#> .
+
+:tdb_dataset_readwrite
+        rdf:type       tdb2:DatasetTDB2;
+        tdb2:location  "/fuseki/databases/core_tdb2" ;
+        tdb2:unionDefaultGraph true .
+
+:service  rdf:type  fuseki:Service;
+        rdfs:label       "TDB2 core";
+        fuseki:dataset   :tdb_dataset_readwrite;
+        fuseki:endpoint  [ fuseki:name       "sparql";
+                           fuseki:operation  fuseki:query
+                         ];
+        fuseki:endpoint  [ fuseki:name       "query";
+                           fuseki:operation  fuseki:query
+                         ];
+        fuseki:endpoint  [ fuseki:operation  fuseki:update ];
+        fuseki:endpoint  [ fuseki:operation  fuseki:query ];
+        fuseki:endpoint  [ fuseki:operation  fuseki:gsp-rw ];
+        fuseki:endpoint  [ fuseki:name       "get";
+                           fuseki:operation  fuseki:gsp-r
+                         ];
+        fuseki:endpoint  [ fuseki:name       "data";
+                           fuseki:operation  fuseki:gsp-rw
+                         ];
+        fuseki:endpoint  [ fuseki:name       "update";
+                           fuseki:operation  fuseki:update
+                         ];
+        fuseki:name      "core" .
+


### PR DESCRIPTION
Migration done manually. This change simply points to the new database.